### PR TITLE
Take description in "APIC" into consideration

### DIFF
--- a/src/frame.c
+++ b/src/frame.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <wchar.h>
 
 #include "frame.h"
 #include "utils.h"


### PR DESCRIPTION
The original code seems to assume an empty description section, so media files with descriptions attached in artwork metadata won't be parsed correctly. Besides, the value of `picture_type` field is also incorrect due to miscalculation of field offset.
