### PR TITLE
compiling and running without segfault

### DIFF
--- a/include/id3v2lib.h
+++ b/include/id3v2lib.h
@@ -17,7 +17,7 @@
 #include "id3v2lib/utils.h"
 
 ID3v2_tag* load_tag(const char* file_name);
-ID3v2_tag* load_tag_with_buffer(char* file, int length);
+ID3v2_tag* load_tag_with_buffer(char* buffer, int length);
 void remove_tag(const char* file_name);
 void set_tag(const char* file_name, ID3v2_tag* tag);
 

--- a/include/id3v2lib.h
+++ b/include/id3v2lib.h
@@ -17,6 +17,7 @@
 #include "id3v2lib/utils.h"
 
 ID3v2_tag* load_tag(const char* file_name);
+ID3v2_tag* load_tag_with_buffer(char* file, int length);
 void remove_tag(const char* file_name);
 void set_tag(const char* file_name, ID3v2_tag* tag);
 

--- a/include/id3v2lib/header.h
+++ b/include/id3v2lib/header.h
@@ -17,6 +17,7 @@
 int has_id3v2tag(ID3v2_header* tag_header);
 int _has_id3v2tag(char* raw_header);
 ID3v2_header* get_tag_header(const char* file_name);
+ID3v2_header* get_tag_header_with_buffer(char* buffer, int length);
 int get_tag_version(ID3v2_header* tag_header);
 void edit_tag_size(ID3v2_tag* tag);
 

--- a/src/header.c
+++ b/src/header.c
@@ -20,7 +20,7 @@ int has_id3v2tag(ID3v2_header* tag_header)
     {
         return 1;
     }
-    
+
     return 0;
 }
 
@@ -30,38 +30,42 @@ int _has_id3v2tag(char* raw_header)
     {
         return 1;
     }
-    
+
     return 0;
 }
 
 ID3v2_header* get_tag_header(const char* file_name)
 {
     char buffer[ID3_HEADER];
-    ID3v2_header* tag_header = new_header();
     FILE* file = fopen(file_name, "rb");
     if(file == NULL)
     {
         perror("Error opening file");
-        free(tag_header);
         return NULL;
     }
-    
+
     fread(buffer, ID3_HEADER, 1, file);
     fclose(file);
-    
-    if( ! _has_id3v2tag(buffer))
-    {
-        free(tag_header);
+    return get_tag_header_with_buffer(buffer, ID3_HEADER);
+}
+ID3v2_header* get_tag_header_with_buffer(char *buffer, int length)
+{
+    if(length < ID3_HEADER) {
         return NULL;
     }
-    
+    if( ! _has_id3v2tag(buffer))
+    {
+        return NULL;
+    }
+    ID3v2_header* tag_header = new_header();
+
     int position = 0;
     memcpy(tag_header->tag, buffer, ID3_HEADER_TAG);
     tag_header->major_version = buffer[position += ID3_HEADER_TAG];
     tag_header->minor_version = buffer[position += ID3_HEADER_VERSION];
     tag_header->flags = buffer[position += ID3_HEADER_REVISION];
     tag_header->tag_size = syncint_decode(btoi(buffer, ID3_HEADER_SIZE, position += ID3_HEADER_FLAGS));
-    
+
     return tag_header;
 }
 

--- a/src/id3v2lib.c
+++ b/src/id3v2lib.c
@@ -66,6 +66,11 @@ ID3v2_tag* load_tag_with_buffer(char *bytes, int length)
         // No compatible ID3 tag in the file, or we got some problem opening the file
         return NULL;
     }
+    if(tag->tag_header->tag_size < length)
+    {
+        // Not enough bytes provided to parse completely. TODO: how to communicate to the user the lack of bytes?
+        return NULL;
+    }
 
     tag = new_tag();
 


### PR DESCRIPTION
From issue 8: 
-----------------

    It would be helpful to add buffer read support besides file reading. I am implementing a file streamer/player at the moment and want to read id3 data directly from the stream. 
There is no library available (i know of) that reads id3 labels from a buffer rather than from a file.

I added methods for being able to use buffers instead of files. The functionality is not broken as all the functions still do the same as they did before. I added new functions for the new functionality. 

Please check out the code and let me know what you think of it.

