### PR TITLE
(#12) Fixed the tag reading bug.

### DIFF
--- a/src/id3v2lib.c
+++ b/src/id3v2lib.c
@@ -26,7 +26,7 @@ ID3v2_tag* load_tag(const char* file_name)
     if(tag_header == NULL) {
         return NULL;
     }
-    header_size = tag_header->tag_size;
+    header_size = tag_header->tag_size + 10;
     free(tag_header);
 
     // allocate buffer and fetch header


### PR DESCRIPTION
Fixed the bug caused by PR #9: Add buffering support.
See Issue #12: *Reading Tags Just Doesn't Work*.

Obviously, this was some incredibly sloppy code that was NEVER TESTED
BY ANYONE, because it obviously doesn't work.

Has this library *really* been completely broken for an entire yearo??