### PR TITLE
Fix seg fault

### DIFF
--- a/src/frame.c
+++ b/src/frame.c
@@ -22,7 +22,7 @@ ID3v2_frame* parse_frame(char* bytes, int offset, int version)
     // Parse frame header
     memcpy(frame->frame_id, bytes + offset, ID3_FRAME_ID);
     // Check if we are into padding
-    if(memcmp(frame->frame_id, "\0\0\0\0", 4) == 0)
+    if(memcmp(frame->frame_id, "\0\0\0\0", 4) == 0 || strlen(frame->frame_id) == 0)
     {
         free(frame);
         return NULL;


### PR DESCRIPTION
With these audio files "Avicii/True/03 Hey Brother.mp3" and "Avicii/True/01 Wake Me Up.mp3" there is a seg fault 11.

I don't know if it's a good workaround, but it's working and no memory leak since.

Have a good day.