### PR TITLE
Genre retireval

### DIFF
--- a/include/id3v2lib/constants.h
+++ b/include/id3v2lib/constants.h
@@ -224,7 +224,7 @@
 #define ID_GOA 126
 #define ID_DRUM_AND_BASS 127
 #define ID_CLUB_HOUSE 128
-#define ID_HARCORE_TECHNO 129
+#define ID_HARDCORE_TECHNO 129
 #define ID_TERROR 130
 #define ID_INDIE 131
 #define ID_BRITPOP 132
@@ -417,7 +417,7 @@
 #define GOA "Goa"
 #define DRUM_AND_BASS "Drum & Bass"
 #define CLUB_HOUSE "Club-House"
-#define HARCORE_TECHNO "Harcore Techno"
+#define HARDCORE_TECHNO "Hardcore Techno"
 #define TERROR "Terror"
 #define INDIE "Indie"
 #define BRITPOP "BritPop"
@@ -425,7 +425,7 @@
 #define POLSK_PUNK "Polsk Punk"
 #define BEAT "Beat"
 #define CHRISTIAN_GANGSTA_RAP "Christian Gangsta Rap"
-#define HEAVY_METAL "Heaby Metal"
+#define HEAVY_METAL "Heavy Metal"
 #define BLACK_METAL "Black Metal"
 #define CROSSOVER "Crossover"
 #define CONTEMPORARY_CHRISTIAN "Contemporary Christian"

--- a/include/id3v2lib/constants.h
+++ b/include/id3v2lib/constants.h
@@ -94,4 +94,15 @@
 #define PUBLISHER_LOGOTYPE 0x14
 // END APIC FRAME CONSTANTS
 
+// Genres:
+#define NUM_BLUES 0
+#define NUM_HIP_HOP 7
+#define NUM_R_AND_B 14
+#define NUM_ROCK 17
+
+#define BLUES "Blues"
+#define HIP_HOP "Hip-Hop"
+#define R_AND_B "R&B"
+#define ROCK "Rock"
+
 #endif

--- a/include/id3v2lib/constants.h
+++ b/include/id3v2lib/constants.h
@@ -95,14 +95,258 @@
 // END APIC FRAME CONSTANTS
 
 // Genres:
-#define NUM_BLUES 0
-#define NUM_HIP_HOP 7
-#define NUM_R_AND_B 14
-#define NUM_ROCK 17
+#define ID_BLUES 0
+#define ID_CLASSIC_ROCK 1
+#define ID_COUNTRY 2
+#define ID_DANCE 3
+#define ID_DISCO 4
+#define ID_FUNK 5
+#define ID_GRUNGE 6
+#define ID_HIP_HOP 7
+#define ID_JAZZ 8
+#define ID_METAL 9
+#define ID_NEW_AGE 10
+#define ID_OLDIES 11
+#define ID_OTHER_GENRE 12
+#define ID_POP 13
+#define ID_R_AND_B 14
+#define ID_RAP 15
+#define ID_REGGAE 16
+#define ID_ROCK 17
+#define ID_TECHNO 18
+#define ID_INDUSTRIAL 19
+#define ID_ALTERNATIVE 20
+#define ID_SKA 21
+#define ID_DEATH_METAL 22
+#define ID_PRANKS 23
+#define ID_SOUNDTRACK 24
+#define ID_EURO_TECHNO 25
+#define ID_AMBIENT 26
+#define ID_TRIP_HOP 27
+#define ID_VOCAL 28
+#define ID_JAZZ_FUNK 29
+#define ID_FUSION 30
+#define ID_TRANCE 31
+#define ID_CLASSICAL 32
+#define ID_INSTRUMENTAL 33
+#define ID_ACID 34
+#define ID_HOUSE 35
+#define ID_GAME 36
+#define ID_SOUND_CLIP 37
+#define ID_GOSPEL 38
+#define ID_NOISE 39
+#define ID_ALTERNATIVE_ROCK 40
+#define ID_BASS 41
+#define ID_SOUL 42
+#define ID_PUNK 43
+#define ID_SPACE 44
+#define ID_MEDITATIVE 45
+#define ID_INSTRUMENTAL_POP 46
+#define ID_INSTRUMENTAL_ROCK 47
+#define ID_ETHIC 48
+#define ID_GOTHIC 49
+#define ID_DARKWAVE 50
+#define ID_TECHNO_INDUSTRIAL 51
+#define ID_ELECTRONIC 52
+#define ID_POP_FOLK 53
+#define ID_EURODANCE 54
+#define ID_DREAM 55
+#define ID_SOUTHERN_ROCK 56
+#define ID_COMEDY 57
+#define ID_CULT 58
+#define ID_GANGSTA 59
+#define ID_TOP_FOURTY 60
+#define ID_CHRISTIAN_RAP 61
+#define ID_POP_FUNK 62
+#define ID_JUNGLE 63
+#define ID_NATIVE_AMERICAN 64
+#define ID_CABARET 65
+#define ID_NEW_WAVE 66
+#define ID_PSYCHADELIC 67
+#define ID_RAVE 68
+#define ID_SHOWTUNES 69
+#define ID_TRAILER 70
+#define ID_LO_FI 71
+#define ID_TRIBAL 72
+#define ID_ACID_PUNK 73
+#define ID_ACID_JAZZ 74
+#define ID_POLKA 75
+#define ID_RETRO 76
+#define ID_MUSICAL 77
+#define ID_ROCK_AND_ROLL 78
+#define ID_HARD_ROCK 79
+#define ID_FOLK 80
+#define ID_FOLK_ROCK 81
+#define ID_NATIONAL_FOLK 82
+#define ID_SWING 83
+#define ID_FAST_FUSION 84
+#define ID_BEBOB 85
+#define ID_LATIN 86
+#define ID_REVIVAL 87
+#define ID_CELTIC 88
+#define ID_BLUEGRASS 89
+#define ID_AVANTGARDE 90
+#define ID_GOTHIC_ROCK 91
+#define ID_PROGRESSIVE_ROCK 92
+#define ID_PSYCHADELIC_ROCK 93
+#define ID_SYMPHONIC_ROCK 94
+#define ID_SLOW_ROCK 95
+#define ID_BIG_BAND 96
+#define ID_CHORUS 97
+#define ID_EASY_LISTENING 98
+#define ID_ACOUSTIC 99
+#define ID_HUMOUR 100
+#define ID_SPEECH 101
+#define ID_CHANSON 102
+#define ID_OPERA 103
+#define ID_CHAMBER_MUSIC 104
+#define ID_SONATA 105
+#define ID_SYMPHONY 106
+#define ID_BOOTY_BASS 107
+#define ID_PRIMUS 108
+#define ID_PORN_GROOVE 109
+#define ID_SATIRE 110
+#define ID_SLOW_JAM 111
+#define ID_CLUB 112
+#define ID_TANGO 113
+#define ID_SAMBA 114
+#define ID_FOLKLORE 115
+#define ID_BALLAD 116
+#define ID_POWER_BALLAD 117
+#define ID_RHYTHMIC_SOUL 118
+#define ID_FREESTYLE 119
+#define ID_DUET 120
+#define ID_PUNK_ROCK 121
+#define ID_DRUM_SOLO 122
+#define ID_A_CAPELLA 123
+#define ID_EURO_HOUSE 124
+#define ID_DANCE_HALL 125
 
 #define BLUES "Blues"
+#define CLASSIC_ROCK "Classic Rock"
+#define COUNTRY "Country"
+#define DANCE "Dance"
+#define DISCO "Disco"
+#define FUNK "Funk"
+#define GRUNGE "Grunge"
 #define HIP_HOP "Hip-Hop"
+#define JAZZ "Jazz"
+#define METAL "Metal"
+#define NEW_AGE "New Age"
+#define OLDIES "Oldies"
+#define OTHER_GENRE "Other"
+#define POP "Pop"
 #define R_AND_B "R&B"
+#define RAP "Rap"
+#define REGGAE "Reggae"
 #define ROCK "Rock"
+#define TECHNO "Techno"
+#define INDUSTRIAL "Industrial"
+#define ALTERNATIVE "Alternative"
+#define SKA "Ska"
+#define DEATH_METAL "Death Metal"
+#define PRANKS "Pranks"
+#define SOUNDTRACK "Sound Track"
+#define EURO_TECHNO "Euro-Techno"
+#define AMBIENT "Ambient"
+#define TRIP_HOP "Trip-Hop"
+#define VOCAL "Vocal"
+#define JAZZ_FUNK "Jazz Funk"
+#define FUSION "Fusion"
+#define TRANCE "Trance"
+#define CLASSICAL "Classical"
+#define INSTRUMENTAL "Instrumental"
+#define ACID "Acid"
+#define HOUSE "House"
+#define GAME "Game"
+#define SOUND_CLIP "Sound Clip"
+#define GOSPEL "Gospel"
+#define NOISE "Noise"
+#define ALTERNATIVE_ROCK "Alternative Rock"
+#define BASS "Bass"
+#define SOUL "Soul"
+#define PUNK "Punk"
+#define SPACE "Space"
+#define MEDITATIVE "Meditative"
+#define INSTRUMENTAL_POP "Instrumental Pop"
+#define INSTRUMENTAL_ROCK "Instrumental Rock"
+#define ETHIC "Ethic"
+#define GOTHIC "Gothic"
+#define DARKWAVE "Dark Wave"
+#define TECHNO_INDUSTRIAL "Techno-Industrial"
+#define ELECTRONIC "Electronic"
+#define POP_FOLK "Pop-Folk"
+#define EURODANCE "Eurodance"
+#define DREAM "Dream"
+#define SOUTHERN_ROCK "Southern Rock"
+#define COMEDY "Comedy"
+#define CULT "Cult"
+#define GANGSTA "Gangsta"
+#define TOP_FOURTY "Top 40"
+#define CHRISTIAN_RAP "Christian Rap"
+#define POP_FUNK "Pop-Funk"
+#define JUNGLE "Jungle"
+#define NATIVE_AMERICAN "Native American"
+#define CABARET "Cabaret"
+#define NEW_WAVE "New Wave"
+#define PSYCHADELIC "Psychadelic"
+#define RAVE "Rave"
+#define SHOWTUNES "Showtunes"
+#define TRAILER "Trailer"
+#define LO_FI "Lo-Fi"
+#define TRIBAL "Tribal"
+#define ACID_PUNK "Acid Punk"
+#define ACID_JAZZ "Acid Jazz"
+#define POLKA "Polka"
+#define RETRO "Retro"
+#define MUSICAL "Musical"
+#define ROCK_AND_ROLL "Rock n' Roll"
+#define HARD_ROCK "Hard Rock"
+#define FOLK "Folk"
+#define FOLK_ROCK "Folk-Rock"
+#define NATIONAL_FOLK "National Folk"
+#define SWING "Swing"
+#define FAST_FUSION "Fast Fusion"
+#define BEBOB "Bebob"
+#define LATIN "Latin"
+#define REVIVAL "Revival"
+#define CELTIC "Celtic"
+#define BLUEGRASS "Bluegrass"
+#define AVANTGARDE "Avantgarde"
+#define GOTHIC_ROCK "Gothic Rock"
+#define PROGRESSIVE_ROCK "Progressive Rock"
+#define PSYCHADELIC_ROCK "Psychadelic Rock"
+#define SYMPHONIC_ROCK "Symphonic Rock"
+#define SLOW_ROCK "Slow Rock"
+#define BIG_BAND "Big Band"
+#define CHORUS "Chorus"
+#define EASY_LISTENING "Easy Listening"
+#define ACOUSTIC "Acoustic"
+#define HUMOUR "Humour"
+#define SPEECH "Speech"
+#define CHANSON "Chanson"
+#define OPERA "Opera"
+#define CHAMBER_MUSIC "Chamber Music"
+#define SONATA "Sonata"
+#define SYMPHONY "Symphony"
+#define BOOTY_BASS "Booty Bass"
+#define PRIMUS "Primus"
+#define PORN_GROOVE "Porn Groove"
+#define SATIRE "Satire"
+#define SLOW_JAM "Slow Jam"
+#define CLUB "Club"
+#define TANGO "Tango"
+#define SAMBA "Samba"
+#define FOLKLORE "Folklore"
+#define BALLAD "Ballad"
+#define POWER_BALLAD "Power Ballad"
+#define RHYTHMIC_SOUL "Rhythmic Soul"
+#define FREESTYLE "Freestyle"
+#define DUET "Duet"
+#define PUNK_ROCK "Punk Rock"
+#define DRUM_SOLO "Drum Solo"
+#define A_CAPELLA "A Capella"
+#define EURO_HOUSE "Euro-House"
+#define DANCE_HALL "Dance Hall"
 
 #endif

--- a/include/id3v2lib/constants.h
+++ b/include/id3v2lib/constants.h
@@ -221,6 +221,72 @@
 #define ID_A_CAPELLA 123
 #define ID_EURO_HOUSE 124
 #define ID_DANCE_HALL 125
+#define ID_GOA 126
+#define ID_DRUM_AND_BASS 127
+#define ID_CLUB_HOUSE 128
+#define ID_HARCORE_TECHNO 129
+#define ID_TERROR 130
+#define ID_INDIE 131
+#define ID_BRITPOP 132
+#define ID_NEGERPUNK 133
+#define ID_POLSK_PUNK 134
+#define ID_BEAT 135
+#define ID_CHRISTIAN_GANGSTA_RAP 136
+#define ID_HEAVY_METAL 137
+#define ID_BLACK_METAL 138
+#define ID_CROSSOVER 139
+#define ID_CONTEMPORARY_CHRISTIAN 140
+#define ID_CHRISTIAN_ROCK 141
+#define ID_MERENGUE 142
+#define ID_SALSA 143
+#define ID_THRASH_METAL 144
+#define ID_ANIME 145
+#define ID_JPOP 146
+#define ID_SYNTHPOP 147
+#define ID_ABSTRACT 148
+#define ID_ART_ROCK 149
+#define ID_BAROQUE 150
+#define ID_BHANGRA 151
+#define ID_BIG_BEAT 152
+#define ID_BREAKBEAT 153
+#define ID_CHILLOUT 154
+#define ID_DOWNTEMPO 155
+#define ID_DUB 156
+#define ID_EBM 157
+#define ID_ECLECTIC 158
+#define ID_ELECTRO 159
+#define ID_ELECTROCLASH 160
+#define ID_EMO 161
+#define ID_EXPERIMENTAL 162
+#define ID_GARAGE 163
+#define ID_GLOBAL 164
+#define ID_IDM 165
+#define ID_ILLBIENT 166
+#define ID_INDUSTRO_GOTH 167
+#define ID_JAM_BAND 168
+#define ID_KRAUTROCK 169
+#define ID_LEFTFIELD 170
+#define ID_LOUNGE 171
+#define ID_MATH_ROCK 172
+#define ID_NEW_ROMANTIC 173
+#define ID_NU_BREAKZ 174
+#define ID_POST_PUNK 175
+#define ID_POST_ROCK 176
+#define ID_PSYTRANCE 177
+#define ID_SHOEGAZE 178
+#define ID_SPACE_ROCK 179
+#define ID_TROP_ROCK 180
+#define ID_WORLD_MUSIC 181
+#define ID_NEOCLASSICAL 182
+#define ID_AUDIOBOOK 183
+#define ID_AUDIO_THEATRE 184
+#define ID_NEUE_DEUTSCHE_WELLE 185
+#define ID_PODCAST 186
+#define ID_INDIE_ROCK 187
+#define ID_G_FUNK 188
+#define ID_DUBSTEP 189
+#define ID_GARAGE_ROCK 190
+#define ID_PSYBIENT 191
 
 #define BLUES "Blues"
 #define CLASSIC_ROCK "Classic Rock"
@@ -348,5 +414,71 @@
 #define A_CAPELLA "A Capella"
 #define EURO_HOUSE "Euro-House"
 #define DANCE_HALL "Dance Hall"
+#define GOA "Goa"
+#define DRUM_AND_BASS "Drum & Bass"
+#define CLUB_HOUSE "Club-House"
+#define HARCORE_TECHNO "Harcore Techno"
+#define TERROR "Terror"
+#define INDIE "Indie"
+#define BRITPOP "BritPop"
+#define NEGERPUNK "Negerpunk"
+#define POLSK_PUNK "Polsk Punk"
+#define BEAT "Beat"
+#define CHRISTIAN_GANGSTA_RAP "Christian Gangsta Rap"
+#define HEAVY_METAL "Heaby Metal"
+#define BLACK_METAL "Black Metal"
+#define CROSSOVER "Crossover"
+#define CONTEMPORARY_CHRISTIAN "Contemporary Christian"
+#define CHRISTIAN_ROCK "Christian rock"
+#define MERENGUE "Merengue"
+#define SALSA "Salsa"
+#define THRASH_METAL "Thrash Metal"
+#define ANIME "Anime"
+#define JPOP "Jpop"
+#define SYNTHPOP "Synthpop"
+#define ABSTRACT "Abstract"
+#define ART_ROCK "Art Rock"
+#define BAROQUE "Baroque"
+#define BHANGRA "Bhangra"
+#define BIG_BEAT "Big beat"
+#define BREAKBEAT "Breakbeat"
+#define CHILLOUT "Chillout"
+#define DOWNTEMPO "Downtempo"
+#define DUB "Dub"
+#define EBM "EBM"
+#define ECLECTIC "Eclectic"
+#define ELECTRO "Electro"
+#define ELECTROCLASH "Electroclash"
+#define EMO "Emo"
+#define EXPERIMENTAL "Experimental"
+#define GARAGE "Garage"
+#define GLOBAL "Global"
+#define IDM "IDM"
+#define ILLBIENT "Illbient"
+#define INDUSTRO_GOTH "Industro-Goth"
+#define JAM_BAND "Jam Band"
+#define KRAUTROCK "Krautrock"
+#define LEFTFIELD "Leftfield"
+#define LOUNGE "Lounge"
+#define MATH_ROCK "Math Rock"
+#define NEW_ROMANTIC "New Romantic"
+#define NU_BREAKZ "Nu-Breakz"
+#define POST_PUNK "Post-Punk"
+#define POST_ROCK "Post-Rock"
+#define PSYTRANCE "Psytrance"
+#define SHOEGAZE "Shoegaze"
+#define SPACE_ROCK "Space Rock"
+#define TROP_ROCK "Trop Rock"
+#define WORLD_MUSIC "World Music"
+#define NEOCLASSICAL "Neoclassical"
+#define AUDIOBOOK "Audiobook"
+#define AUDIO_THEATRE "Audio theatre"
+#define NEUE_DEUTSCHE_WELLE "Neue Deutsche Welle"
+#define PODCAST "Podcast"
+#define INDIE_ROCK "Indie-Rock"
+#define G_FUNK "G-Funk"
+#define DUBSTEP "Dubstep"
+#define GARAGE_ROCK "Garage Rock"
+#define PSYBIENT "Psybient"
 
 #endif

--- a/include/id3v2lib/utils.h
+++ b/include/id3v2lib/utils.h
@@ -29,7 +29,7 @@ ID3v2_frame* get_from_list(ID3v2_frame_list* list, char* frame_id);
 void free_tag(ID3v2_tag* tag);
 char* get_mime_type_from_filename(const char* filename);
 
-void genre_num_string(char* genre_data, char* dest);
+void genre_num_string(char* dest, char *genre_data);
 char* convert_genre_number(int number);
 
 // String functions

--- a/include/id3v2lib/utils.h
+++ b/include/id3v2lib/utils.h
@@ -29,6 +29,9 @@ ID3v2_frame* get_from_list(ID3v2_frame_list* list, char* frame_id);
 void free_tag(ID3v2_tag* tag);
 char* get_mime_type_from_filename(const char* filename);
 
+void genre_num_string(char* genre_data, char* dest);
+char* convert_genre_number(int number);
+
 // String functions
 int has_bom(uint16_t* string);
 uint16_t* char_to_utf16(char* string, int size);

--- a/src/frame.c
+++ b/src/frame.c
@@ -65,11 +65,12 @@ ID3v2_frame_text_content* parse_text_frame_content(ID3v2_frame* frame)
     {
         return NULL;
     }
-    
+
     content = new_text_content(frame->size);
     content->encoding = frame->data[0];
-    content->size = frame->size - ID3_FRAME_ENCODING;
+    content->size = frame->size;
     memcpy(content->data, frame->data + ID3_FRAME_ENCODING, content->size);
+
     return content;
 }
 

--- a/src/frame.c
+++ b/src/frame.c
@@ -68,7 +68,7 @@ ID3v2_frame_text_content* parse_text_frame_content(ID3v2_frame* frame)
 
     content = new_text_content(frame->size);
     content->encoding = frame->data[0];
-    content->size = frame->size;
+    content->size = frame->size - ID3_FRAME_ENCODING;
     memcpy(content->data, frame->data + ID3_FRAME_ENCODING, content->size);
 
     return content;

--- a/src/utils.c
+++ b/src/utils.c
@@ -139,7 +139,6 @@ void genre_num_string(char* genre_data, char* dest)
 {
     if (genre_data == NULL)
     {
-	printf("genre data is null\n");
         return;
     }
 
@@ -151,47 +150,412 @@ void genre_num_string(char* genre_data, char* dest)
     
     for (int i = 0; i < length; ++i)
     {
-	printf("Searching the char is %c\n", genre_data[i]);
         if (genre_data[i] == '(' && first_parenthesis_found == 1)
 	{
-            //printf("First parenthese found\n");
 	    first_parenthesis_found = 0;
 	    continue;
 	}
-	if (genre_data[i] == ')' && second_parenthese_found == 1 )//&&
-	        //first_parenthesis_found == 0)
+	if (genre_data[i] == ')' && second_parenthese_found == 1 )
 	{
-	    //printf("Second parenthesis found\n");
 	    second_parenthese_found = 0;
 	    break;
 	}
 	if (first_parenthesis_found == 0)
 	{
 	    genre_number[genre_number_index++] = genre_data[i];
-	    printf("%s", genre_number);
 	}
     }
 
     if (first_parenthesis_found == 1 || second_parenthese_found == 1) {
-        printf("Genre already set or does not exist\n");
 	return;
     }
 
-    printf("%s %d", genre_number, atoi(genre_number));
     char* dest_tmp = convert_genre_number(atoi(genre_number));
     strcpy(dest, dest_tmp);
 }
 
 char* convert_genre_number(int number)
 {
-    char *genre = "dd";
+    char *genre;
     switch (number)
     {
-	case NUM_HIP_HOP:
+	case ID_BLUES:
+	    genre = BLUES;
+	    break;
+	case ID_CLASSIC_ROCK:
+	    genre = CLASSIC_ROCK;
+	    break;
+	case ID_COUNTRY:
+	    genre = COUNTRY;
+	    break;
+	case ID_DANCE:
+	    genre = DANCE;
+	    break;
+	case ID_DISCO:
+	    genre = DISCO;
+	    break;
+	case ID_FUNK:
+	    genre = FUNK;
+	    break;
+	case ID_GRUNGE:
+	    genre = GRUNGE;
+	    break;
+	case ID_HIP_HOP:
 	    genre = HIP_HOP;
 	    break;
-        case NUM_R_AND_B:
+	case ID_JAZZ:
+	    genre = JAZZ;
+	    break;
+	case ID_METAL:
+	    genre = METAL;
+	    break;
+	case ID_NEW_AGE:
+	    genre = NEW_AGE;
+	    break;
+	case ID_OLDIES:
+	    genre = OLDIES;
+	    break;
+	case ID_OTHER_GENRE:
+	    genre = OTHER_GENRE;
+	    break;
+	case ID_POP:
+	    genre = POP;
+	    break;
+        case ID_R_AND_B:
 	    genre = R_AND_B;
+	    break;
+	case ID_RAP:
+	    genre = RAP;
+	    break;
+	case ID_REGGAE:
+	    genre = REGGAE;
+	    break;
+	case ID_ROCK:
+	    genre = ROCK;
+	    break;
+	case ID_TECHNO:
+	    genre = TECHNO;
+	    break;
+	case ID_INDUSTRIAL:
+	    genre = INDUSTRIAL;
+	    break;
+	case ID_ALTERNATIVE:
+	    genre = ALTERNATIVE;
+	    break;
+	case ID_SKA:
+	    genre = SKA;
+	    break;
+	case ID_DEATH_METAL:
+	    genre = DEATH_METAL;
+	    break;
+	case ID_PRANKS:
+	    genre = PRANKS;
+	    break;
+	case ID_SOUNDTRACK:
+	    genre = SOUNDTRACK;
+	    break;
+	case ID_EURO_TECHNO:
+	    genre = EURO_TECHNO;
+	    break;
+	case ID_AMBIENT:
+	    genre = AMBIENT;
+	    break;
+	case ID_TRIP_HOP:
+	    genre = TRIP_HOP;
+	    break;
+	case ID_VOCAL:
+	    genre = VOCAL;
+	    break;
+	case ID_JAZZ_FUNK:
+	    genre = JAZZ_FUNK;
+	    break;
+	case ID_FUSION:
+	    genre = FUSION;
+	    break;
+	case ID_TRANCE:
+	    genre = TRANCE;
+	    break;
+	case ID_CLASSICAL:
+	    genre = CLASSICAL;
+	    break;
+	case ID_INSTRUMENTAL:
+	    genre = INSTRUMENTAL;
+	    break;
+	case ID_ACID:
+	    genre = ACID;
+	    break;
+	case ID_HOUSE:
+	    genre = HOUSE;
+	    break;
+	case ID_GAME:
+	    genre = GAME;
+	    break;
+	case ID_SOUND_CLIP:
+	    genre = SOUND_CLIP;
+	    break;
+	case ID_GOSPEL:
+	    genre = GOSPEL;
+	    break;
+	case ID_NOISE:
+	    genre = NOISE;
+	    break;
+	case ID_ALTERNATIVE_ROCK:
+	    genre = ALTERNATIVE_ROCK;
+	    break;
+	case ID_BASS:
+	    genre = BASS;
+	    break;
+	case ID_SOUL:
+	    genre = SOUL;
+	    break;
+	case ID_PUNK:
+	    genre = PUNK;
+	    break;
+	case ID_SPACE:
+	    genre = SPACE;
+	    break;
+	case ID_MEDITATIVE:
+	    genre = MEDITATIVE;
+	    break;
+	case ID_INSTRUMENTAL_POP:
+	    genre = INSTRUMENTAL_POP;
+	    break;
+	case ID_INSTRUMENTAL_ROCK:
+	    genre = INSTRUMENTAL_ROCK;
+	    break;
+	case ID_ETHIC:
+	    genre = ETHIC;
+	    break;
+	case ID_GOTHIC:
+	    genre = GOTHIC;
+	    break;
+	case ID_DARKWAVE:
+	    genre = DARKWAVE;
+	    break;
+	case ID_TECHNO_INDUSTRIAL:
+	    genre = TECHNO_INDUSTRIAL;
+	    break;
+	case ID_ELECTRONIC:
+	    genre = ELECTRONIC;
+	    break;
+	case ID_POP_FOLK:
+	    genre = POP_FOLK;
+	    break;
+	case ID_EURODANCE:
+	    genre = EURODANCE;
+	    break;
+	case ID_DREAM:
+	    genre = DREAM;
+	    break;
+	case ID_SOUTHERN_ROCK:
+	    genre = SOUTHERN_ROCK;
+	    break;
+	case ID_COMEDY:
+	    genre = COMEDY;
+	    break;
+	case ID_CULT:
+	    genre = CULT;
+	    break;
+	case ID_GANGSTA:
+	    genre = GANGSTA;
+	    break;
+	case ID_TOP_FOURTY:
+	    genre = TOP_FOURTY;
+	    break;
+	case ID_CHRISTIAN_RAP:
+	    genre = CHRISTIAN_RAP;
+	    break;
+	case ID_POP_FUNK:
+	    genre = POP_FUNK;
+	    break;
+	case ID_JUNGLE:
+	    genre = JUNGLE;
+	    break;
+	case ID_NATIVE_AMERICAN:
+	    genre = NATIVE_AMERICAN;
+	    break;
+	case ID_CABARET:
+	    genre = CABARET;
+	    break;
+	case ID_NEW_WAVE:
+	    genre = NEW_WAVE;
+	    break;
+	case ID_PSYCHADELIC:
+	    genre = PSYCHADELIC;
+	    break;
+	case ID_RAVE:
+	    genre = RAVE;
+	    break;
+	case ID_SHOWTUNES:
+	    genre = SHOWTUNES;
+	    break;
+	case ID_TRAILER:
+	    genre = TRAILER;
+	    break;
+	case ID_LO_FI:
+	    genre = LO_FI;
+	    break;
+	case ID_TRIBAL:
+	    genre = TRIBAL;
+	    break;
+	case ID_ACID_PUNK:
+	    genre = ACID_PUNK;
+	    break;
+	case ID_ACID_JAZZ:
+	    genre = ACID_JAZZ;
+	    break;
+	case ID_POLKA:
+	    genre = POLKA;
+	    break;
+	case ID_RETRO:
+	    genre = RETRO;
+	    break;
+	case ID_MUSICAL:
+	    genre = MUSICAL;
+	    break;
+	case ID_ROCK_AND_ROLL:
+	    genre = ROCK_AND_ROLL;
+	    break;
+	case ID_HARD_ROCK:
+	    genre = HARD_ROCK;
+	    break;
+	case ID_FOLK:
+	    genre = FOLK;
+	    break;
+	case ID_FOLK_ROCK:
+	    genre = FOLK_ROCK;
+	    break;
+	case ID_NATIONAL_FOLK:
+	    genre = NATIONAL_FOLK;
+	    break;
+	case ID_SWING:
+	    genre = SWING;
+	    break;
+	case ID_FAST_FUSION:
+	    genre = FAST_FUSION;
+	    break;
+	case ID_BEBOB:
+	    genre = BEBOB;
+	    break;
+	case ID_LATIN:
+	    genre = LATIN;
+	    break;
+	case ID_REVIVAL:
+	    genre = REVIVAL;
+	    break;
+	case ID_CELTIC:
+	    genre = CELTIC;
+	    break;
+	case ID_BLUEGRASS:
+	    genre = BLUEGRASS;
+	    break;
+	case ID_AVANTGARDE:
+	    genre = AVANTGARDE;
+	    break;
+	case ID_GOTHIC_ROCK:
+	    genre = GOTHIC_ROCK;
+	    break;
+	case ID_PROGRESSIVE_ROCK:
+	    genre = PROGRESSIVE_ROCK;
+	    break;
+	case ID_PSYCHADELIC_ROCK:
+	    genre = PSYCHADELIC_ROCK;
+	    break;
+	case ID_SYMPHONIC_ROCK:
+	    genre = SYMPHONIC_ROCK;
+	    break;
+	case ID_SLOW_ROCK:
+	    genre = SLOW_ROCK;
+	    break;
+	case ID_BIG_BAND:
+	    genre = BIG_BAND;
+	    break;
+	case ID_CHORUS:
+	    genre = CHORUS;
+	    break;
+	case ID_EASY_LISTENING:
+	    genre = EASY_LISTENING;
+	    break;
+	case ID_ACOUSTIC:
+	    genre = ACOUSTIC;
+	    break;
+	case ID_HUMOUR:
+	    genre = HUMOUR;
+	    break;
+	case ID_SPEECH:
+	    genre = SPEECH;
+	    break;
+	case ID_CHANSON:
+	    genre = CHANSON;
+	    break;
+	case ID_OPERA:
+	    genre = OPERA;
+	    break;
+	case ID_CHAMBER_MUSIC:
+	    genre = CHAMBER_MUSIC;
+	    break;
+	case ID_SONATA:
+	    genre = SONATA;
+	    break;
+	case ID_SYMPHONY:
+	    genre = SYMPHONY;
+	    break;
+	case ID_BOOTY_BASS:
+	    genre = BOOTY_BASS;
+	    break;
+	case ID_PRIMUS:
+	    genre = PRIMUS;
+	    break;
+	case ID_PORN_GROOVE:
+	    genre = PORN_GROOVE;
+	    break;
+	case ID_SATIRE:
+	    genre = SATIRE;
+	    break;
+	case ID_SLOW_JAM:
+	    genre = SLOW_JAM;
+	    break;
+	case ID_CLUB:
+	    genre = CLUB;
+	    break;
+	case ID_TANGO:
+	    genre = TANGO;
+	    break;
+	case ID_SAMBA:
+	    genre = SAMBA;
+	    break;
+	case ID_FOLKLORE:
+	    genre = FOLKLORE;
+	    break;
+	case ID_BALLAD:
+	    genre = BALLAD;
+	    break;
+	case ID_POWER_BALLAD:
+	    genre = POWER_BALLAD;
+	    break;
+	case ID_RHYTHMIC_SOUL:
+	    genre = RHYTHMIC_SOUL;
+	    break;
+	case ID_FREESTYLE:
+	    genre = FREESTYLE;
+	    break;
+	case ID_DUET:
+	    genre = DUET;
+	    break;
+	case ID_PUNK_ROCK:
+	    genre = PUNK_ROCK;
+	    break;
+	case ID_DRUM_SOLO:
+	    genre = DRUM_SOLO;
+	    break;
+	case ID_A_CAPELLA:
+	    genre = A_CAPELLA;
+	    break;
+	case ID_EURO_HOUSE:
+	    genre = EURO_HOUSE;
+	    break;
+	case ID_DANCE_HALL:
+	    genre = DANCE_HALL;
 	    break;
     }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -557,6 +557,204 @@ char* convert_genre_number(int number)
 	case ID_DANCE_HALL:
 	    genre = DANCE_HALL;
 	    break;
+        case ID_GOA:
+	    genre = GOA;
+	    break;
+	case ID_DRUM_AND_BASS:
+	    genre = DRUM_AND_BASS;
+	    break;
+	case ID_CLUB_HOUSE:
+	    genre = CLUB_HOUSE;
+	    break;
+	case ID_HARDCORE_TECHNO:
+	    genre = HARDCORE_TECHNO;
+	    break;
+	case ID_TERROR:
+	    genre = TERROR;
+	    break;
+	case ID_INDIE:
+	    genre = INDIE;
+	    break;
+	case ID_BRITPOP:
+	    genre = BRITPOP;
+	    break;
+	case ID_NEGERPUNK:
+	    genre = NEGERPUNK;
+	    break;
+	case ID_POLSK_PUNK:
+	    genre = POLSK_PUNK;
+	    break;
+	case ID_BEAT:
+	    genre = BEAT;
+	    break;
+	case ID_CHRISTIAN_GANGSTA_RAP:
+	    genre = CHRISTIAN_GANGSTA_RAP;
+	    break;
+	case ID_HEAVY_METAL:
+	    genre = HEAVY_METAL;
+	    break;
+	case ID_BLACK_METAL:
+	    genre = BLACK_METAL;
+	    break;
+	case ID_CROSSOVER:
+	    genre = CROSSOVER;
+	    break;
+	case ID_CONTEMPORARY_CHRISTIAN:
+	    genre = CONTEMPORARY_CHRISTIAN;
+	    break;
+	case ID_CHRISTIAN_ROCK:
+	    genre = CHRISTIAN_ROCK;
+	    break;
+	case ID_MERENGUE:
+	    genre = MERENGUE;
+	    break;
+	case ID_SALSA:
+	    genre = SALSA;
+	    break;
+	case ID_THRASH_METAL:
+	    genre = THRASH_METAL;
+	    break;
+	case ID_ANIME:
+	    genre = ANIME;
+	    break;
+	case ID_JPOP:
+	    genre = JPOP;
+	    break;
+	case ID_SYNTHPOP:
+	    genre = SYNTHPOP;
+	    break;
+	case ID_ABSTRACT:
+	    genre = ABSTRACT;
+	    break;
+	case ID_ART_ROCK:
+	    genre = ART_ROCK;
+	    break;
+	case ID_BAROQUE:
+	    genre = BAROQUE;
+	    break;
+	case ID_BHANGRA:
+	    genre = BHANGRA;
+	    break;
+	case ID_BIG_BEAT:
+	    genre = BIG_BEAT;
+	    break;
+	case ID_BREAKBEAT:
+	    genre = BREAKBEAT;
+	    break;
+	case ID_CHILLOUT:
+	    genre = CHILLOUT;
+	    break;
+	case ID_DOWNTEMPO:
+	    genre = DOWNTEMPO;
+	    break;
+	case ID_DUB:
+	    genre = DUB;
+	    break;
+	case ID_EBM:
+	    genre = EBM;
+	    break;
+	case ID_ECLECTIC:
+	    genre = ECLECTIC;
+	    break;
+	case ID_ELECTRO:
+	    genre = ELECTRO;
+	    break;
+	case ID_ELECTROCLASH:
+	    genre = ELECTROCLASH;
+	    break;
+	case ID_EMO:
+	    genre = EMO;
+	    break;
+	case ID_EXPERIMENTAL:
+	    genre = EXPERIMENTAL;
+	    break;
+	case ID_GARAGE:
+	    genre = GARAGE;
+	    break;
+	case ID_GLOBAL:
+	    genre = GLOBAL;
+	    break;
+	case ID_IDM:
+	    genre = IDM;
+	    break;
+	case ID_ILLBIENT:
+	    genre = ILLBIENT;
+	    break;
+	case ID_INDUSTRO_GOTH:
+	    genre = INDUSTRO_GOTH;
+	    break;
+	case ID_JAM_BAND:
+	    genre = JAM_BAND;
+	    break;
+	case ID_KRAUTROCK:
+	    genre = KRAUTROCK;
+	    break;
+	case ID_LEFTFIELD:
+	    genre = LEFTFIELD;
+	    break;
+	case ID_LOUNGE:
+	    genre = LOUNGE;
+	    break;
+	case ID_MATH_ROCK:
+	    genre = MATH_ROCK;
+	    break;
+	case ID_NEW_ROMANTIC:
+	    genre = NEW_ROMANTIC;
+	    break;
+	case ID_NU_BREAKZ:
+	    genre = NU_BREAKZ;
+	    break;
+	case ID_POST_PUNK:
+	    genre = POST_PUNK;
+	    break;
+	case ID_POST_ROCK:
+	    genre = POST_ROCK;
+	    break;
+	case ID_PSYTRANCE:
+	    genre = PSYTRANCE;
+	    break;
+	case ID_SHOEGAZE:
+	    genre = SHOEGAZE;
+	    break;
+	case ID_SPACE_ROCK:
+	    genre = SPACE_ROCK;
+	    break;
+	case ID_TROP_ROCK:
+	    genre = TROP_ROCK;
+	    break;
+	case ID_WORLD_MUSIC:
+	    genre = WORLD_MUSIC;
+	    break;
+	case ID_NEOCLASSICAL:
+	    genre = NEOCLASSICAL;
+	    break;
+	case ID_AUDIOBOOK:
+	    genre = AUDIOBOOK;
+	    break;
+	case ID_AUDIO_THEATRE:
+	    genre = AUDIO_THEATRE;
+	    break;
+	case ID_NEUE_DEUTSCHE_WELLE:
+	    genre = NEUE_DEUTSCHE_WELLE;
+	    break;
+	case ID_PODCAST:
+	    genre = PODCAST;
+	    break;
+	case ID_INDIE_ROCK:
+	    genre = INDIE_ROCK;
+	    break;
+	case ID_G_FUNK:
+	    genre = G_FUNK;
+	    break;
+	case ID_DUBSTEP:
+	    genre = DUBSTEP;
+	    break;
+	case ID_GARAGE_ROCK:
+	    genre = GARAGE_ROCK;
+	    break;
+	case ID_PSYBIENT:
+	    genre = PSYBIENT;
+	    break;
     }
 
     return genre;

--- a/src/utils.c
+++ b/src/utils.c
@@ -135,10 +135,9 @@ char* get_mime_type_from_filename(const char* filename)
     }
 }
 
-void genre_num_string(char* genre_data, char* dest)
+void genre_num_string(char* dest, char *genre_data)
 {
-    if (genre_data == NULL)
-    {
+    if (genre_data == NULL) {
         return;
     }
 
@@ -148,37 +147,36 @@ void genre_num_string(char* genre_data, char* dest)
     int first_parenthesis_found = 1;
     int second_parenthese_found = 1;
     
-    for (int i = 0; i < length; ++i)
-    {
-        if (genre_data[i] == '(' && first_parenthesis_found == 1)
-	{
+    for (int i = 0; i < length; ++i) {
+        if (genre_data[i] == '(' && first_parenthesis_found == 1) {
 	    first_parenthesis_found = 0;
 	    continue;
 	}
-	if (genre_data[i] == ')' && second_parenthese_found == 1 )
-	{
+	if (genre_data[i] == ')' && second_parenthese_found == 1 ) {
 	    second_parenthese_found = 0;
 	    break;
 	}
-	if (first_parenthesis_found == 0)
-	{
+	if (first_parenthesis_found == 0) {
 	    genre_number[genre_number_index++] = genre_data[i];
 	}
     }
 
     if (first_parenthesis_found == 1 || second_parenthese_found == 1) {
+	printf("nothing found\n");
+	strcpy(dest, genre_data);
 	return;
     }
 
-    char* dest_tmp = convert_genre_number(atoi(genre_number));
-    strcpy(dest, dest_tmp);
+    int genre_id = atoi(genre_number);
+    char *genre = convert_genre_number(genre_id);
+    strcpy(dest, genre);
 }
 
 char* convert_genre_number(int number)
 {
     char *genre;
-    switch (number)
-    {
+
+    switch (number) {
 	case ID_BLUES:
 	    genre = BLUES;
 	    break;

--- a/src/utils.c
+++ b/src/utils.c
@@ -135,6 +135,69 @@ char* get_mime_type_from_filename(const char* filename)
     }
 }
 
+void genre_num_string(char* genre_data, char* dest)
+{
+    if (genre_data == NULL)
+    {
+	printf("genre data is null\n");
+        return;
+    }
+
+    int length = strlen(genre_data);
+    int genre_number_index = 0;
+    char genre_number[3];
+    int first_parenthesis_found = 1;
+    int second_parenthese_found = 1;
+    
+    for (int i = 0; i < length; ++i)
+    {
+	printf("Searching the char is %c\n", genre_data[i]);
+        if (genre_data[i] == '(' && first_parenthesis_found == 1)
+	{
+            //printf("First parenthese found\n");
+	    first_parenthesis_found = 0;
+	    continue;
+	}
+	if (genre_data[i] == ')' && second_parenthese_found == 1 )//&&
+	        //first_parenthesis_found == 0)
+	{
+	    //printf("Second parenthesis found\n");
+	    second_parenthese_found = 0;
+	    break;
+	}
+	if (first_parenthesis_found == 0)
+	{
+	    genre_number[genre_number_index++] = genre_data[i];
+	    printf("%s", genre_number);
+	}
+    }
+
+    if (first_parenthesis_found == 1 || second_parenthese_found == 1) {
+        printf("Genre already set or does not exist\n");
+	return;
+    }
+
+    printf("%s %d", genre_number, atoi(genre_number));
+    char* dest_tmp = convert_genre_number(atoi(genre_number));
+    strcpy(dest, dest_tmp);
+}
+
+char* convert_genre_number(int number)
+{
+    char *genre = "dd";
+    switch (number)
+    {
+	case NUM_HIP_HOP:
+	    genre = HIP_HOP;
+	    break;
+        case NUM_R_AND_B:
+	    genre = R_AND_B;
+	    break;
+    }
+
+    return genre;
+}
+
 // String functions
 int has_bom(uint16_t* string)
 {


### PR DESCRIPTION
Feature for retrieving the genre name if the genre from the ID3v2_frame_text_content data member is in the ID3 format like this `(7)` which would be Hip-Hop. The supported genres can be found [here](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=5&cad=rja&uact=8&ved=2ahUKEwi9yM7J6OfiAhWFnOAKHdBeB0cQygQwBHoECAAQBg&url=http%3A%2F%2Fid3.org%2Fid3v2.3.0%23Appendix_A_-_Genre_List_from_ID3v1&usg=AOvVaw2z_NeAff1zfwDeTcHnudH8). The function to parse the genre number is 
```C 
void genre_num_string(char* genre_data, char* dest);
```

The genre_data parameter would be the ID3v2_frame_text_context->data variable and the dest parameter would be where the appropriate genre would be assigned to.