### PR TITLE
Add Frame Flag Initialization

### DIFF
--- a/src/types.c
+++ b/src/types.c
@@ -39,6 +39,7 @@ ID3v2_header* new_header()
 ID3v2_frame* new_frame()
 {
     ID3v2_frame* frame = (ID3v2_frame*) malloc(sizeof(ID3v2_frame));
+    memset(frame->flags, 0, ID3_FRAME_FLAGS);
     return frame;
 }
 


### PR DESCRIPTION
Added initialization code for Frame Flags.
For example, an uninitialized value is inserted in Frame Flags when:

```
ID3v2_tag* id3tag = new_tag();
tag_set_title("title", 0, id3tag);
set_tag("/home/test.mp3", id3Tag);
```