### PR TITLE
Check result of fread call

### DIFF
--- a/src/header.c
+++ b/src/header.c
@@ -37,6 +37,7 @@ int _has_id3v2tag(char* raw_header)
 ID3v2_header* get_tag_header(const char* file_name)
 {
     char buffer[ID3_HEADER];
+    int res;
     FILE* file = fopen(file_name, "rb");
     if(file == NULL)
     {
@@ -44,8 +45,9 @@ ID3v2_header* get_tag_header(const char* file_name)
         return NULL;
     }
 
-    fread(buffer, ID3_HEADER, 1, file);
+    res = fread(buffer, ID3_HEADER, 1, file);
     fclose(file);
+    if (!res) return NULL; // less than ID3_HEADER bytes in file
     return get_tag_header_with_buffer(buffer, ID3_HEADER);
 }
 ID3v2_header* get_tag_header_with_buffer(char *buffer, int length)


### PR DESCRIPTION
The function `get_tag_header` calls `fread(buffer, ID3_HEADER, 1, file)` to indicate that it absolutely needs 10 bytes to work on, but it doesn't assign the result of this call. When the file is shorter than 10 bytes, the `fread` call returns 0 and leaves `buffer` indeterminate. In these conditions, `buffer` should not be passed to the function `get_tag_header_with_buffer`, which would find itself processing indeterminate data.

This pull request makes `get_tag_header` return `NULL` when the `fread` call returns 0.