### PR TITLE
ID3v2_Tag_get_frame now takes const char* and moved TagHeader_free to public header.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ build/
 .DS_Store
 .idea/
 .vscode/
+.ccls-cache/
 main_test

--- a/include/modules/tag.h
+++ b/include/modules/tag.h
@@ -37,13 +37,13 @@ void ID3v2_Tag_free(ID3v2_Tag* tag);
  * Returns the first frame found with the provided id. If you need
  * more than the first occurrence, then, use ID3v2_Tag_get_frames(tag, frame_id);
  */
-ID3v2_Frame* ID3v2_Tag_get_frame(ID3v2_Tag* tag, char* frame_id);
+ID3v2_Frame* ID3v2_Tag_get_frame(ID3v2_Tag* tag, const char* frame_id);
 
 /**
  * Returns all the frames matching frame_id in a sublist. If you only need
  * the first occurrence, then, use ID3v2_Tag_get_frame(tag, frame_id);
  */
-ID3v2_FrameList* ID3v2_Tag_get_frames(ID3v2_Tag* tag, char* frame_id);
+ID3v2_FrameList* ID3v2_Tag_get_frames(ID3v2_Tag* tag, const char* frame_id);
 
 ID3v2_TextFrame* ID3v2_Tag_get_artist_frame(ID3v2_Tag* tag);
 ID3v2_TextFrame* ID3v2_Tag_get_album_frame(ID3v2_Tag* tag);

--- a/include/modules/tag_header.h
+++ b/include/modules/tag_header.h
@@ -28,4 +28,6 @@ typedef struct _ID3v2_TagHeader
     unsigned int extended_header_size;
 } ID3v2_TagHeader;
 
+void TagHeader_free(ID3v2_TagHeader* header);
+
 #endif

--- a/include/modules/tag_header.h
+++ b/include/modules/tag_header.h
@@ -28,6 +28,6 @@ typedef struct _ID3v2_TagHeader
     unsigned int extended_header_size;
 } ID3v2_TagHeader;
 
-void TagHeader_free(ID3v2_TagHeader* header);
+void ID3v2_TagHeader_free(ID3v2_TagHeader* header);
 
 #endif

--- a/src/id3v2lib.c
+++ b/src/id3v2lib.c
@@ -56,7 +56,7 @@ ID3v2_Tag* ID3v2_read_tag(const char* file_name)
     {
         perror("Could not allocate buffer.");
         fclose(file);
-        TagHeader_free(tag_header);
+        ID3v2_TagHeader_free(tag_header);
         return NULL;
     }
 
@@ -66,7 +66,7 @@ ID3v2_Tag* ID3v2_read_tag(const char* file_name)
     ID3v2_Tag* tag = ID3v2_read_tag_from_buffer(tag_buffer, buffer_length);
 
     free(tag_buffer);
-    TagHeader_free(tag_header);
+    ID3v2_TagHeader_free(tag_header);
 
     return tag;
 }
@@ -158,7 +158,7 @@ void ID3v2_delete_tag(const char* file_name)
         putc(c, file_fp);
     }
 
-    TagHeader_free(tag_header);
+    ID3v2_TagHeader_free(tag_header);
 
     fclose(temp_fp);
     fclose(file_fp);

--- a/src/id3v2lib.compat.c
+++ b/src/id3v2lib.compat.c
@@ -135,7 +135,7 @@ ID3v2_tag* load_tag(const char* file_name)
     ID3v2_tag* tag = load_tag_with_buffer(buffer, buffer_size);
 
     free(buffer);
-    TagHeader_free(header);
+    ID3v2_TagHeader_free(header);
 
     return tag;
 }

--- a/src/modules/tag.c
+++ b/src/modules/tag.c
@@ -108,13 +108,13 @@ CharStream* Tag_to_char_stream(ID3v2_Tag* tag)
 /**
  * Getter functions
  */
-ID3v2_Frame* ID3v2_Tag_get_frame(ID3v2_Tag* tag, char* frame_id)
+ID3v2_Frame* ID3v2_Tag_get_frame(ID3v2_Tag* tag, const char* frame_id)
 {
     if (tag == NULL) return NULL;
     return FrameList_get_frame_by_id(tag->frames, frame_id);
 }
 
-ID3v2_FrameList* ID3v2_Tag_get_frames(ID3v2_Tag* tag, char* frame_id)
+ID3v2_FrameList* ID3v2_Tag_get_frames(ID3v2_Tag* tag, const char* frame_id)
 {
     if (tag == NULL) return NULL;
     return FrameList_get_frames_by_id(tag->frames, frame_id);

--- a/src/modules/tag.c
+++ b/src/modules/tag.c
@@ -447,7 +447,7 @@ void ID3v2_Tag_set_album_cover(
 
 void ID3v2_Tag_free(ID3v2_Tag* tag)
 {
-    TagHeader_free(tag->header);
+    ID3v2_TagHeader_free(tag->header);
     ID3v2_FrameList_free(tag->frames);
     free(tag);
 }

--- a/src/modules/tag_header.c
+++ b/src/modules/tag_header.c
@@ -81,7 +81,7 @@ ID3v2_TagHeader* TagHeader_parse(CharStream* header_cs)
     return TagHeader_new(major_version, minor_version, flags, tag_size, extended_header_size);
 }
 
-void TagHeader_free(ID3v2_TagHeader* header)
+void ID3v2_TagHeader_free(ID3v2_TagHeader* header)
 {
     free(header);
 }

--- a/src/modules/tag_header.private.h
+++ b/src/modules/tag_header.private.h
@@ -24,6 +24,4 @@ ID3v2_TagHeader* TagHeader_new(
 ID3v2_TagHeader* TagHeader_new_empty();
 ID3v2_TagHeader* TagHeader_parse(CharStream* stream);
 
-void TagHeader_free(ID3v2_TagHeader* header);
-
 #endif


### PR DESCRIPTION
fixes #44 
fixes #45 