### PR TITLE
Fix memory leak when freeing unknown frame types.

### DIFF
--- a/include/modules/tag.h
+++ b/include/modules/tag.h
@@ -62,6 +62,16 @@ ID3v2_FrameList* ID3v2_Tag_get_apic_frames(ID3v2_Tag* tag);
 /**
  * Setter functions
  */
+typedef struct _ID3v2_FrameInput
+{
+    const char* id;
+    const char* flags;
+    const char* data;
+    const int size;
+} ID3v2_FrameInput;
+
+void ID3v2_Tag_set_frame(ID3v2_Tag* tag, const ID3v2_FrameInput* input);
+
 typedef struct _ID3v2_TextFrameInput
 {
     const char* id;

--- a/src/modules/frame.c
+++ b/src/modules/frame.c
@@ -104,5 +104,6 @@ void ID3v2_Frame_free(ID3v2_Frame* frame)
         // Unknown frame id, naively try our best to free it
         free(frame->header);
         free(frame->data);
+        free(frame);
     }
 }

--- a/test/assertion_utils.c
+++ b/test/assertion_utils.c
@@ -24,6 +24,21 @@ void assert_frame_header(ID3v2_Frame* frame, Frame_header_assertion comparison)
     assert(memcmp(frame->header->flags, comparison.flags, ID3v2_FRAME_HEADER_FLAGS_LENGTH) == 0);
 }
 
+void assert_frame(ID3v2_Frame* frame, ID3v2_FrameInput* comparison) {
+    // Header
+    assert_frame_header(
+        frame,
+        (Frame_header_assertion){
+            .id = comparison->id,
+            .size = comparison->size,
+            .flags = comparison->flags,
+        }
+    );
+
+    // Data
+    assert(memcmp(frame->data, comparison->data, comparison->size) == 0);   
+}
+
 void assert_text_frame(ID3v2_TextFrame* frame, ID3v2_TextFrameInput* comparison)
 {
     const char encoding = has_bom(comparison->text) ? ID3v2_ENCODING_UNICODE : ID3v2_ENCODING_ISO;

--- a/test/assertion_utils.h
+++ b/test/assertion_utils.h
@@ -19,6 +19,7 @@ typedef struct _Frame_header_assertion
     const char* flags;
 } Frame_header_assertion;
 
+void assert_frame(ID3v2_Frame* frame, ID3v2_FrameInput* comparison);
 void assert_frame_header(ID3v2_Frame* frame, Frame_header_assertion comparison);
 void assert_text_frame(ID3v2_TextFrame* frame, ID3v2_TextFrameInput* comparison);
 void assert_comment_frame(ID3v2_CommentFrame* frame, ID3v2_CommentFrameInput* comparison);

--- a/test/set_test.c
+++ b/test/set_test.c
@@ -248,6 +248,31 @@ void edit_test()
 
 void new_tag_test()
 {
+    const char* frame_id = "GEOB";
+    const char frame_data[8] = {0xD, 0xE, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF};
+
+    // set a new, non-standard frame
+    ID3v2_Tag* tag = ID3v2_Tag_new_empty();   
+    ID3v2_FrameInput new_frame = {
+        .id = frame_id,
+        .flags = "\0\0",
+        .data = &frame_data[0],
+        .size = 8
+    };
+    ID3v2_Tag_set_frame(tag, &new_frame);
+
+    // verify the frame
+    assert_frame(
+        ID3v2_Tag_get_frame(tag, frame_id), 
+        &(ID3v2_FrameInput){
+            .id = frame_id,
+            .flags = "\0\0",
+            .data = &frame_data[0],
+            .size = 8,
+        }
+    );
+
+    ID3v2_Tag_free(tag);
 }
 
 void set_test_main()


### PR DESCRIPTION
Hi, 

There seems to be a memory leak when freeing frames of an unknown type. I discovered this while analysing my library that depends on id3v2 with valgrind. I've added a test case and supporting code to demonstrate the leak, then fixed it in the next commit.

It's an easy thing to miss, the frame itself wasn't being freed when the frame type was unknown, whereas it is freed by the frame types specific functions.

I've verified before & after with `valgrind --leak-check=full ./main_test`:
<details><summary>Valgrind logs with leak</summary>

```==8597== Memcheck, a memory error detector
==8597== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==8597== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==8597== Command: ./main_test
==8597== 
==8597== Warning: client switching stacks?  SP change: 0x1ffed32100 --> 0x1ffeffec90
==8597==          to suppress, use: --max-stackframe=2935696 or greater
GET TEST EXISTING: OK
GET TEST EMPTY: OK
==8597== Warning: client switching stacks?  SP change: 0x1ffed32070 --> 0x1ffeffec00
==8597==          to suppress, use: --max-stackframe=2935696 or greater
==8597== Warning: client switching stacks?  SP change: 0x1ffed32070 --> 0x1ffeffec00
==8597==          to suppress, use: --max-stackframe=2935696 or greater
==8597==          further instances of this message will not be shown.
SET TEST: OK
DELETE TEST: OK
COMPAT TEST: OK
==8597== 
==8597== HEAP SUMMARY:
==8597==     in use at exit: 16 bytes in 1 blocks
==8597==   total heap usage: 1,119 allocs, 1,118 frees, 108,869,627 bytes allocated
==8597== 
==8597== 16 bytes in 1 blocks are definitely lost in loss record 1 of 1
==8597==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==8597==    by 0x10C864: ID3v2_Tag_set_frame (tag.c:222)
==8597==    by 0x10B566: new_tag_test (set_test.c:262)
==8597==    by 0x10B5EC: set_test_main (set_test.c:281)
==8597==    by 0x10ABBD: main (main_test.c:20)
==8597== 
==8597== LEAK SUMMARY:
==8597==    definitely lost: 16 bytes in 1 blocks
==8597==    indirectly lost: 0 bytes in 0 blocks
==8597==      possibly lost: 0 bytes in 0 blocks
==8597==    still reachable: 0 bytes in 0 blocks
==8597==         suppressed: 0 bytes in 0 blocks
==8597== 
==8597== For lists of detected and suppressed errors, rerun with: -s
==8597== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
</details>

<details><summary>Valgrind logs after fix</summary>

```
==9784== Memcheck, a memory error detector
==9784== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==9784== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==9784== Command: ./main_test
==9784== 
==9784== Warning: client switching stacks?  SP change: 0x1ffed320f0 --> 0x1ffeffec80
==9784==          to suppress, use: --max-stackframe=2935696 or greater
GET TEST EXISTING: OK
GET TEST EMPTY: OK
==9784== Warning: client switching stacks?  SP change: 0x1ffed32060 --> 0x1ffeffebf0
==9784==          to suppress, use: --max-stackframe=2935696 or greater
==9784== Warning: client switching stacks?  SP change: 0x1ffed32060 --> 0x1ffeffebf0
==9784==          to suppress, use: --max-stackframe=2935696 or greater
==9784==          further instances of this message will not be shown.
SET TEST: OK
DELETE TEST: OK
COMPAT TEST: OK
==9784== 
==9784== HEAP SUMMARY:
==9784==     in use at exit: 0 bytes in 0 blocks
==9784==   total heap usage: 1,119 allocs, 1,119 frees, 108,869,627 bytes allocated
==9784== 
==9784== All heap blocks were freed -- no leaks are possible
==9784== 
==9784== For lists of detected and suppressed errors, rerun with: -s
==9784== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

</details>